### PR TITLE
Adding support for underscores and dashes in the youtube id

### DIFF
--- a/players/youtube/popcorn.youtube.js
+++ b/players/youtube/popcorn.youtube.js
@@ -59,7 +59,7 @@ var onYouTubePlayerReady;
       return;
     }
     
-    var matches = url.match( /((http:\/\/)?www\.)?youtube\.[a-z]+\/watch\?v\=[a-z0-9]+/i );    
+    var matches = url.match( /((http:\/\/)?www\.)?youtube\.[a-z]+\/watch\?v\=[a-z0-9_-]+/i );    
     // Return id, which comes after first equals sign
     return matches ? matches[0].split( "=" )[1] : "";
   }
@@ -70,7 +70,7 @@ var onYouTubePlayerReady;
       return;
     }
     
-    var matches = url.match( /^http:\/\/?www\.youtube\.[a-z]+\/e\/[a-z0-9]+/i );
+    var matches = url.match( /^http:\/\/?www\.youtube\.[a-z]+\/e\/[a-z0-9_-]+/i );
     
     // Return id, which comes after first equals sign
     return matches ? matches[0].split( "/e/" )[1] : "";

--- a/players/youtube/popcorn.youtube.unit.js
+++ b/players/youtube/popcorn.youtube.unit.js
@@ -165,12 +165,12 @@ test( "Popcorn YouTube Plugin Url and Duration Tests", function() {
   
   var count = 0,
       expects = 3,
-      popcorn = Popcorn( Popcorn.youtube( 'video2', 'http://www.youtube.com/watch?v=9oar9glUCL0' ) );
+      popcorn = Popcorn( Popcorn.youtube( 'video2', 'http://www.youtube.com/watch?v=2w-_Vtttrfc' ) );
       
   expect( expects );
   stop( 10000 );
   
-  equals( popcorn.video.vidId, '9oar9glUCL0', 'Video id set' );
+  equals( popcorn.video.vidId, '2w-_Vtttrfc', 'Video id set' );
   plus();
   
   equals( popcorn.duration(), 0, 'Duration starts as 0');


### PR DESCRIPTION
Not totally sure how this process work (sorry) - but here's an patch that fixes certain youtube videos with punctuation in the video id.

See also:

https://webmademovies.lighthouseapp.com/projects/63272/tickets/517-some-youtube-videos-dont-work-contain-underscores-and-such
