### PR TITLE
[#1156] create track event _id before setup is called, still allow user ...

### DIFF
--- a/popcorn.js
+++ b/popcorn.js
@@ -860,7 +860,7 @@
 
     if ( track._natives ) {
       //  Supports user defined track event id
-      track._id = !track.id ? Popcorn.guid( track._natives.type ) : track.id;
+      track._id = track.id || track._id || Popcorn.guid( track._natives.type );
 
       //  Push track event ids into the history
       obj.data.history.push( track._id );
@@ -1464,6 +1464,11 @@
         manifestOpts = "options" in manifest && manifest.options;
 
         options.target = manifestOpts && "target" in manifestOpts && manifestOpts.target;
+      }
+
+      if ( options._natives ) {
+        // ensure an initial id is there before setup is called
+        options._id = Popcorn.guid( options._natives.type );
       }
 
       // Trigger _setup method if exists

--- a/test/popcorn.unit.js
+++ b/test/popcorn.unit.js
@@ -1830,6 +1830,23 @@ test( "UI/Mouse", function() {
 });
 
 module( "Popcorn Plugin" );
+
+test( "Plugin _id applied before setup", function() {
+
+  expect( 1 );
+
+  var p = Popcorn( "#video" );
+
+  Popcorn.plugin( "idPlugin", {
+    _setup: function( options ) {
+      ok( options._id, "_id was set before setup" );
+      Popcorn.removePlugin( "idPlugin" );
+    }
+  });
+
+  p.idPlugin({});
+});
+
 test( "Manifest", function() {
 
   var p = Popcorn( "#video" ),


### PR DESCRIPTION
...defined ids, and still support addTrackEvent called outside of a plugin, in the case of internal padding plugins.
