### PR TITLE
[#1192] Added URL params parsing for YouTube player

### DIFF
--- a/players/youtube/popcorn.youtube.js
+++ b/players/youtube/popcorn.youtube.js
@@ -175,7 +175,7 @@ Popcorn.player( "youtube", {
 
     var youtubeInit = function() {
 
-      var src, query;
+      var src, query, params, playerVars, queryStringItem;
 
       var timeUpdate = function() {
 
@@ -226,13 +226,13 @@ Popcorn.player( "youtube", {
 
       autoPlay = ( /autoplay=1/.test( query ) );
 
-      var params = query.split( /[\&\?]/g );
-      var playerVars = { wmode: "transparent" };
+      params = query.split( /[\&\?]/g );
+      playerVars = { wmode: "transparent" };
 
       for( var i = 0; i < params.length; i++ ) {
-        var parts = params[ i ].split( "=" );
+        queryStringItem = params[ i ].split( "=" );
 
-        playerVars[ parts[ 0 ] ] = parts[ 1 ];
+        playerVars[ queryStringItem[ 0 ] ] = queryStringItem[ 1 ];
       }
       
       options.youtubeObject = new YT.Player( container.id, {


### PR DESCRIPTION
Fix for Lighthouse issue [#1192](https://webmademovies.lighthouseapp.com/projects/63272/tickets/1192-youtube-player-no-longer-accepts-additional-params).

I would have written a test, but the entire YouTube player test suite was broken on my computer.  Failed 3 out of 7 tests on the first parts and stopped running the tests by the time it hit Part 3.  So I was unable to make that work.  I would be happy to write one once the test suite itself works.
