### PR TITLE
[#1195] Removes Popcorn.extend(options, options), in favor of just 'options'

### DIFF
--- a/popcorn.js
+++ b/popcorn.js
@@ -1613,7 +1613,7 @@
       options._natives._setup && options._natives._setup.call( this, options );
 
       // Create new track event for this instance
-      Popcorn.addTrackEvent( this, Popcorn.extend( options, options ) );
+      Popcorn.addTrackEvent( this, options );
 
       //  Future support for plugin event definitions
       //  for all of the native events


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/63272-popcornjs/tickets/1195-fix-overlooked-popcornextend-options-options
