### PR TITLE
[#1194] Fix for YouTube duration detection, with refactoring of YT duration/ready events

### DIFF
--- a/players/youtube/popcorn.youtube.js
+++ b/players/youtube/popcorn.youtube.js
@@ -204,7 +204,9 @@ Popcorn.player( "youtube", {
         var ytDuration = options.youtubeObject.getDuration();
 
         if ( isNaN( ytDuration ) || ytDuration === 0 ) {
-          setTimeout( function() { fetchDuration( delay * 2 ); }, delay*1000 );
+          setTimeout( function() {
+            fetchDuration( delay * 2 );
+          }, delay*1000 );
         } else {
           // set duration and dispatch ready events
           media.duration = ytDuration;


### PR DESCRIPTION
Fix for Lighthouse issue [#1194](https://webmademovies.lighthouseapp.com/projects/63272/tickets/1194-youtube-duration-issues).

Delays duration detection until the video starts playing, then polls with a repeating decay to match with YouTube's documented "shortly after play" duration availability.  Also refactors the duration/ready events to work with this.
