### PR TITLE
[#1230] Fix subtitles positioning in relative-positioned containers

### DIFF
--- a/plugins/subtitle/popcorn.subtitle.js
+++ b/plugins/subtitle/popcorn.subtitle.js
@@ -6,30 +6,33 @@
       createDefaultContainer = function( context, id ) {
 
         var ctxContainer = context.container = document.createElement( "div" ),
+            extContainer = document.createElement( "div" ),
             style = ctxContainer.style,
             media = context.media;
 
-        var updatePosition = function() {
-          var position = context.position();
-          // the video element must have height and width defined
-          style.fontSize = "18px";
-          style.width = media.offsetWidth + "px";
-          style.top = position.top  + media.offsetHeight - ctxContainer.offsetHeight - 40 + "px";
-          style.left = position.left + "px";
+        extContainer.style.position = "relative";
+        extContainer.appendChild( ctxContainer );
 
-          setTimeout( updatePosition, 10 );
+        // we update sub position regularly in case video is resized
+        var updatePosition = function() {
+          // the video element must have height and width defined
+          style.width = media.offsetWidth + "px";
+          style.top = media.offsetHeight - ctxContainer.offsetHeight - 40 + "px";
+
+          setTimeout( updatePosition, 100 );
         };
 
         ctxContainer.id = id || Popcorn.guid();
         style.position = "absolute";
         style.color = "white";
         style.textShadow = "black 2px 2px 6px";
+        style.fontSize = "18px";
         style.fontWeight = "bold";
         style.textAlign = "center";
 
         updatePosition();
 
-        context.media.parentNode.appendChild( ctxContainer );
+        media.parentNode.insertBefore( extContainer, media );
 
         return ctxContainer;
       };

--- a/plugins/subtitle/popcorn.subtitle.unit.js
+++ b/plugins/subtitle/popcorn.subtitle.unit.js
@@ -2,7 +2,7 @@ asyncTest( "Popcorn Subtitle Plugin", function() {
 
   var popped = Popcorn( "#video" ),
       popped2 = Popcorn( "#video2" ),
-      expects = 12,
+      expects = 7,
       count = 0,
       subTop = 9001,
       subLeft = 9001,
@@ -72,33 +72,6 @@ asyncTest( "Popcorn Subtitle Plugin", function() {
     popped.media.style.position = "absolute";
     popped.media.style.left = "400px";
     popped.media.style.top = "600px";
-    popped.media.play();
-
-  });
-
-  popped.exec( 3, function() {
-
-    popped.media.pause();
-
-    // check position of subttile that should of moved with video,
-    // a subtitle must be displayed to get valid data
-    ok( subtitlediv.style.left !== subLeft, "subtitle's left position has changed" );
-    plus();
-    ok( subtitlediv.style.top !== subTop, "subtitle's top position has changed" );
-    plus();
-
-    // we know values have changed, but how accurate are they?
-    // check values against the video's values
-    // we need four checks because if we just check against video's position,
-    // and video's position hasn't updated either, we'll pass when we should fail
-    equal( subtitlediv.style.left, popped.position().left + "px", "subtitle left position moved" );
-    plus();
-    ok( Popcorn.position( subtitlediv ).top > popped.position().top, "subtitle top position moved" );
-    plus();
-
-    equal( subtitlediv.children[ 1 ].innerHTML, "this is the second subtitle of 2011", "subtitle displaying correct information" );
-    plus();
-
     popped.media.play();
 
   });


### PR DESCRIPTION
Fix for Lighthouse [#1230](https://webmademovies.lighthouseapp.com/projects/63272-popcornjs/tickets/1230-subtitles-positioning-breaks-when-container-has-relative-position)

Add relatively-positioned container element to improve positioning, remove obsolete tests now that browser handles repositioning.
