### PR TITLE
[#1227] rAF test workaround for IE9, fix for compose tests, so they work...

### DIFF
--- a/test/popcorn.unit.js
+++ b/test/popcorn.unit.js
@@ -2535,10 +2535,10 @@ asyncTest( "frame function (frameAnimation)", 1, function() {
 
   timeout = setTimeout(function() {
 
-    ok( "IE9 has trouble with this rAF test, skipping" );
+    ok( true, "IE9 has trouble with this rAF test, skipping" );
     Popcorn.removePlugin( "frameFn" );
     start();
-  }, 10000)
+  }, 10000 );
 });
 
 test( "Update Timer (timeupdate)", function() {


### PR DESCRIPTION
... in IE9

There's still issues with other tests, like enable/disable, as well as XML test issues.
