### PR TITLE
[#1235] Make TTML use text if textContent is undefined, fixing TTMLParse...

### DIFF
--- a/parsers/parserTTML/popcorn.parserTTML.js
+++ b/parsers/parserTTML/popcorn.parserTTML.js
@@ -105,7 +105,7 @@
     var sub = {};
 
     // Trim left and right whitespace from text and convert non-explicit line breaks
-    sub.text = node.textContent.replace( rWhitespace, "" ).replace( rLineBreak, "<br />" );
+    sub.text = ( node.textContent || node.text ).replace( rWhitespace, "" ).replace( rLineBreak, "<br />" );
     sub.id = node.getAttribute( "xml:id" ) || node.getAttribute( "id" );
     sub.start = toSeconds ( node.getAttribute( "begin" ), timeOffset );
     sub.end = toSeconds( node.getAttribute( "end" ), timeOffset );


### PR DESCRIPTION
...r work in IE9

https://webmademovies.lighthouseapp.com/projects/63272-popcornjs/tickets/1235-ttml-tests-fail-when-using-textcontent
