### PR TITLE
[#1205] Added waiting event in playerQueue and canplay/loadstart events for YouTube

### DIFF
--- a/players/youtube/popcorn.youtube.js
+++ b/players/youtube/popcorn.youtube.js
@@ -223,6 +223,8 @@
             media.readyState = 4;
 
             timeUpdate();
+
+            media.dispatchEvent( "canplay" );
             media.dispatchEvent( "canplaythrough" );
           }
         };
@@ -282,6 +284,9 @@
               options.youtubeObject.playVideo();
 
               media.currentTime = fragmentStart;
+
+              media.dispatchEvent( "loadstart" );
+
               // wait to dispatch ready events until we get a duration
             },
             "onStateChange": function( state ){


### PR DESCRIPTION
Fix for Lighthouse issue [#1205](https://webmademovies.lighthouseapp.com/projects/63272/tickets/1205-youtube-does-not-have-a-canplay-loadstart-or-waiting-event)

I added a waiting event dispatch in the playerQueue add method so it is available to all players.  I also added canplay and loadstart events to the YouTube player.
