### PR TITLE
Bug 1298 - Enable dom.find() to handle non-String types

### DIFF
--- a/popcorn.js
+++ b/popcorn.js
@@ -1902,13 +1902,11 @@
     find: function( selector, context ) {
       var node = null;
 
-      //  Trim leading/trailing whitespace to avoid false negatives
-      selector = selector.trim();
-
       //  Default context is the `document`
       context = context || document;
 
       if ( selector ) {
+
         //  If the selector does not begin with "#", "." or "[",
         //  it could be either a nodeName or ID w/o "#"
         if ( !rnaiveExpr.test( selector ) ) {

--- a/test/popcorn.unit.js
+++ b/test/popcorn.unit.js
@@ -1367,7 +1367,11 @@ test( "Popcorn.dom.find() Returns null for invalid selectors", function() {
   var fixture = document.getElementById("video"),
       allowed = [
         { desc: "closing bracket", selector: "]" },
-        { desc: "escapes \\",      selector: "\/" }
+        { desc: "escapes \\",      selector: "\/" },
+        { desc: "null",            selector: null },
+        { desc: "undefined",       selector: undefined },
+        { desc: "true (Boolean)",  selector: true },
+        { desc: "7 (Number)",      selector: 7 }
       ];
 
   expect( allowed.length );


### PR DESCRIPTION
Fixes Wikipedia plugin in Butter.
