### PR TITLE
[#1312] Popcorn.smart now uses fallback players if a wrapper isn't provided

### DIFF
--- a/modules/player/popcorn.player.js
+++ b/modules/player/popcorn.player.js
@@ -366,7 +366,7 @@
       // See if we can use a wrapper directly, if not, try players.
       for ( j = 0; j < wrappers.length; j++ ) {
         mediaWrapper = Popcorn[ wrappers[ j ] ];
-        if ( mediaWrapper._canPlaySrc( srci ) === "probably" ) {
+        if ( mediaWrapper && mediaWrapper._canPlaySrc( srci ) === "probably" ) {
           media = mediaWrapper( node );
           popcorn = Popcorn( media, options );
           // Set src, but not until after we return the media so the caller


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/63272-popcornjs/tickets/1312-popcornsmart-will-never-use-old-players-as-fallback-if-a-wrapper-isnt-provided
