### PR TITLE
[#1304] Track Event updating now works for track events not created with a custom id initially

### DIFF
--- a/popcorn.js
+++ b/popcorn.js
@@ -968,11 +968,12 @@
 
   // Internal Only - Adds track events to the instance object
   Popcorn.addTrackEvent = function( obj, track ) {
-    var trackEvent, isUpdate, eventType;
+    var trackEvent, isUpdate, eventType,
+        id = track.id || track._id;
 
     // Do a lookup for existing trackevents with this id
-    if ( track.id ) {
-      trackEvent = obj.getTrackEvent( track.id );
+    if ( id ) {
+      trackEvent = obj.getTrackEvent( id );
     }
 
     // If a track event by this id currently exists, modify it
@@ -983,7 +984,7 @@
       track = Popcorn.extend( {}, trackEvent, track );
 
       // Remove the existing track from the instance
-      obj.removeTrackEvent( track.id );
+      obj.removeTrackEvent( id );
     }
 
     // Determine if this track has default options set for it

--- a/test/popcorn.unit.js
+++ b/test/popcorn.unit.js
@@ -4440,6 +4440,35 @@ asyncTest( "Create empty cue and modify later", 5, function() {
 
 });
 
+asyncTest( "Create empty trackevent w/o id and modify later", 2, function() {
+  var p = Popcorn( "#video" ),
+      id,
+      trackEvent,
+      numTrackEvents;
+
+  Popcorn.plugin( "testplugin", {} );
+
+  p.testplugin( { text: "Initial Text" } );
+
+  numTrackEvents = p.data.trackEvents.byStart.length;
+
+  id = p.getLastTrackEventId();
+
+  trackEvent = p.getTrackEvent( id );
+
+  p.testplugin( id, { text: "New Text" } );
+
+  trackEvent = p.getTrackEvent( id );
+
+  equal( p.data.trackEvents.byStart.length, numTrackEvents, "Modifying trackevent later didn't create extra trackevents." );
+  equal( trackEvent.text, "New Text", "Properly updated the trackevent with the value \"New Text\"" );
+
+  Popcorn.removePlugin( "testplugin" );
+  p.destroy();
+
+  start();
+});
+
 module( "Popcorn XHR" );
 test( "Basic", 2, function() {
 


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/63272/tickets/1304-modifying-a-trackevent-after-creation-creates-additional-track-events
