### PR TITLE
[#1307] Updating a plugin after creation now calls setup in addition to teardown

### DIFF
--- a/popcorn.js
+++ b/popcorn.js
@@ -1001,6 +1001,9 @@
 
       //  Push track event ids into the history
       obj.data.history.push( track._id );
+
+      // Trigger _setup method if exists
+      track._natives._setup && track._natives._setup.call( this, track );
     }
 
     track.start = Popcorn.util.toSeconds( track.start, obj.options.framerate );
@@ -1654,9 +1657,6 @@
         // ensure an initial id is there before setup is called
         options._id = Popcorn.guid( options._natives.type );
       }
-
-      // Trigger _setup method if exists
-      options._natives._setup && options._natives._setup.call( this, options );
 
       // Create new track event for this instance
       Popcorn.addTrackEvent( this, options );

--- a/test/popcorn.unit.js
+++ b/test/popcorn.unit.js
@@ -4469,6 +4469,36 @@ asyncTest( "Create empty trackevent w/o id and modify later", 2, function() {
   start();
 });
 
+test( "Modify trackevent after creation call teardown/setup", 3, function() {
+  var p = Popcorn( "#video" ),
+      id,
+      count = 0;
+
+  Popcorn.plugin( "testplugin", {
+    _setup: function( options ) {
+      if ( ++count === 2 ) {
+        ok( true, "Setup was properly called." );
+        equal( options.text, "New Text", "Successfully passed the new options to the plugin for setup" );
+      }
+    },
+    start: function(){},
+    end: function(){},
+    _teardown: function( options ) {
+      ok( true, "Teardown was properly called" );
+    }
+  });
+
+  p.testplugin( { text: "Initial Text" } );
+
+  id = p.getLastTrackEventId();
+
+  p.testplugin( id, { text: "New Text" } );
+
+  Popcorn.removePlugin( "testplugin" );
+  p.destroy();
+
+});
+
 module( "Popcorn XHR" );
 test( "Basic", 2, function() {
 


### PR DESCRIPTION
https://webmademovies.lighthouseapp.com/projects/63272/tickets/1307-updating-trackevents-should-call-_setup
