### PR TITLE
[#1325] Add ability to remove listeners by function equality

### DIFF
--- a/popcorn.js
+++ b/popcorn.js
@@ -915,10 +915,22 @@
         return this;
       },
       unlisten: function( type, fn ) {
+        var events = this.data.events[ type ];
 
-        if ( this.data.events[ type ] && this.data.events[ type ][ fn ] ) {
+        if ( !events ) {
+          return; // no listeners = nothing to do
+        }
 
-          delete this.data.events[ type ][ fn ];
+        if ( typeof fn === "string" && events[ fn ] ) {
+          delete events[ fn ];
+
+          return this;
+        } else if ( typeof fn === "function" ) {
+          for ( var i in events ) {
+            if ( hasOwn.call( events, i ) && events[ i ] === fn ) {
+              delete events[ i ];
+            }
+          }
 
           return this;
         }


### PR DESCRIPTION
Fixes Lighthouse ticket #[1325](https://webmademovies.lighthouseapp.com/projects/63272-popcornjs/tickets/1325-off-should-unlisten-by-function-equality-not-by-name).

Modifies unlisten() function (aliased as off()) to allow passing a function in, and deleting matching functions.
