### PR TITLE
[#1336] Switch wrappers width/height to 100%

### DIFF
--- a/wrappers/null/popcorn.HTMLNullVideoElement.js
+++ b/wrappers/null/popcorn.HTMLNullVideoElement.js
@@ -77,8 +77,8 @@
         poster: EMPTY_STRING,
         volume: 1,
         muted: false,
-        width: parent.width|0   ? parent.width  : self._util.MIN_WIDTH,
-        height: parent.height|0 ? parent.height : self._util.MIN_HEIGHT,
+        width: '100%',
+        height: '100%',
         seeking: false,
         ended: false,
         paused: 1, // 1 vs. true to differentiate first time access

--- a/wrappers/soundcloud/popcorn.HTMLSoundCloudAudioElement.js
+++ b/wrappers/soundcloud/popcorn.HTMLSoundCloudAudioElement.js
@@ -66,8 +66,8 @@
         duration: NaN,
         ended: false,
         paused: true,
-        width: parent.width|0   ? parent.width  : self._util.MIN_WIDTH,
-        height: parent.height|0 ? parent.height : self._util.MIN_HEIGHT,
+        width: '100%',
+        height: '100%',
         error: null
       },
       playerReady = false,

--- a/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js
+++ b/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js
@@ -76,8 +76,8 @@
         duration: NaN,
         ended: false,
         paused: true,
-        width: parent.width|0   ? parent.width  : MIN_WIDTH,
-        height: parent.height|0 ? parent.height : MIN_HEIGHT,
+        width: '100%',
+        height: '100%',
         error: null
       },
       playerReady = false,

--- a/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
+++ b/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
@@ -79,8 +79,8 @@
         duration: NaN,
         ended: false,
         paused: true,
-        width: parent.width|0   ? parent.width  : MIN_WIDTH,
-        height: parent.height|0 ? parent.height : MIN_HEIGHT,
+        width: '100%',
+        height: '100%',
         error: null
       },
       playerReady = false,


### PR DESCRIPTION
Fixes Lighthouse issue #1336.

Switches wrappers' width/height to 100%, like the players are, so that they work with newly created DOM elements.
