### PR TITLE
[#1330] Return 0 for width/height in wrappers if element not yet created

### DIFF
--- a/wrappers/null/popcorn.HTMLNullVideoElement.js
+++ b/wrappers/null/popcorn.HTMLNullVideoElement.js
@@ -324,7 +324,7 @@
 
       width: {
         get: function() {
-          return elem.width;
+          return elem ? elem.width : impl.width || 0;
         },
         set: function( aValue ) {
           impl.width = aValue;
@@ -333,7 +333,7 @@
 
       height: {
         get: function() {
-          return elem.height;
+          return elem ? elem.height : impl.height || 0;
         },
         set: function( aValue ) {
           impl.height = aValue;

--- a/wrappers/soundcloud/popcorn.HTMLSoundCloudAudioElement.js
+++ b/wrappers/soundcloud/popcorn.HTMLSoundCloudAudioElement.js
@@ -520,7 +520,7 @@
 
       width: {
         get: function() {
-          return elem.width;
+          return elem ? elem.width : impl.width || 0;
         },
         set: function( aValue ) {
           impl.width = aValue;
@@ -529,7 +529,7 @@
 
       height: {
         get: function() {
-          return elem.height;
+          return elem ? elem.height : impl.height || 0;
         },
         set: function( aValue ) {
           impl.height = aValue;

--- a/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js
+++ b/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js
@@ -520,7 +520,7 @@
 
       width: {
         get: function() {
-          return elem.width;
+          return elem ? elem.width : impl.width || 0;
         },
         set: function( aValue ) {
           impl.width = aValue;
@@ -529,7 +529,7 @@
 
       height: {
         get: function() {
-          return elem.height;
+          return elem ? elem.height : impl.height || 0;
         },
         set: function( aValue ) {
           impl.height = aValue;

--- a/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
+++ b/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
@@ -530,7 +530,7 @@
 
       width: {
         get: function() {
-          return elem.width;
+          return elem ? elem.width : impl.width || 0;
         },
         set: function( aValue ) {
           impl.width = aValue;
@@ -539,7 +539,7 @@
 
       height: {
         get: function() {
-          return elem.height;
+          return elem ? elem.height : impl.height || 0;
         },
         set: function( aValue ) {
           impl.height = aValue;


### PR DESCRIPTION
Fixes Lighthouse issue #1330.

Returns 0 in all wrappers for width/height if the internal element is not yet created (to avoid an error).
