### PR TITLE
[#1342] Rework SoundCloud controls=false loading logic, add _util.type f...

### DIFF
--- a/wrappers/common/popcorn._MediaElementProto.js
+++ b/wrappers/common/popcorn._MediaElementProto.js
@@ -75,6 +75,9 @@
 
     _util: {
 
+      // Each wrapper stamps a type.
+      type: "HTML5",
+
       // How often to trigger timeupdate events
       TIMEUPDATE_MS: 250,
 

--- a/wrappers/null/popcorn.HTMLNullVideoElement.js
+++ b/wrappers/null/popcorn.HTMLNullVideoElement.js
@@ -93,6 +93,9 @@
     // Attach parentNode
     self.parentNode = parent;
 
+    // Mark type as NullVideo
+    self._util.type = "NullVideo";
+
     function addPlayerReadyCallback( callback ) {
       playerReadyCallbacks.unshift( callback );
     }

--- a/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js
+++ b/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js
@@ -93,6 +93,9 @@
 
     self.parentNode = parent;
 
+    // Mark type as Vimeo
+    self._util.type = "Vimeo";
+
     function addPlayerReadyCallback( callback ) {
       playerReadyCallbacks.unshift( callback );
     }

--- a/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
+++ b/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
@@ -97,6 +97,9 @@
 
     self.parentNode = parent;
 
+    // Mark this as YouTube
+    self._util.type = "YouTube";
+
     function addPlayerReadyCallback( callback ) {
       playerReadyCallbacks.unshift( callback );
     }


### PR DESCRIPTION
...or all wrappers in order to identify SoundCloud wrapper at runtime
