### PR TITLE
[#1346] Ensure YouTube wrapper fires seek if play hasn't been called yet

### DIFF
--- a/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
+++ b/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
@@ -388,6 +388,11 @@
       }
       impl.seeking = true;
       self.dispatchEvent( "seeking" );
+      
+      // start monitorCurrentTime interval in case we haven't played yet
+      if ( !currentTimeInterval ) {
+        currentTimeInterval = setInterval( monitorCurrentTime, CURRENT_TIME_MONITOR_MS );
+      }
     }
 
     function onSeeked() {


### PR DESCRIPTION
Fixes Lighthouse issue #1346.

Makes sure YT wrapper fires the seek event even if the video hasn't been played yet.
