### PR TITLE
[#1367] If plugin definitions use a function, store that has the plugin ...

### DIFF
--- a/popcorn.js
+++ b/popcorn.js
@@ -1202,7 +1202,7 @@
   }
 
   // Internal Only - Adds track events to the instance object
-  Popcorn.addTrackEvent = function( obj, track ) {
+  Popcorn.addTrackEvent = function( obj, track, definition ) {
     var trackEvent, isUpdate, eventType, id;
 
     // Construct new track event instance object
@@ -1244,11 +1244,14 @@
       if ( track._natives._setup ) {
 
         track._natives._setup.call( obj, track );
-        obj.emit( "tracksetup", Popcorn.extend( {}, track, {
-          plugin: track._natives.type,
-          type: "tracksetup"
-        }));
+      } else if ( typeof definition === "function" ) {
+        track._natives._setup = definition;
       }
+
+      obj.emit( "tracksetup", Popcorn.extend( {}, track, {
+        plugin: track._natives.type,
+        type: "tracksetup"
+      }));
     }
 
     addToArray( obj, track );
@@ -1636,7 +1639,7 @@
       definition[ method ] = safeTry( definition[ method ] || Popcorn.nop, name );
     });
 
-    var pluginFn = function( setup, options ) {
+    var pluginFn = function( setup, options, definition ) {
 
       if ( !options ) {
         return this;
@@ -1774,7 +1777,7 @@
       }
 
       // Create new track event for this instance
-      Popcorn.addTrackEvent( this, options );
+      Popcorn.addTrackEvent( this, options, definition );
 
       //  Future support for plugin event definitions
       //  for all of the native events
@@ -1850,7 +1853,7 @@
       mergedSetupOpts = Popcorn.extend( {}, defaults, options );
 
       return pluginFn.call( this, isfn ? definition.call( this, mergedSetupOpts ) : definition,
-                                  mergedSetupOpts );
+                                  mergedSetupOpts, definition );
     };
 
     // if the manifest parameter exists we should extend it onto the definition object

--- a/test/popcorn.unit.js
+++ b/test/popcorn.unit.js
@@ -4716,6 +4716,36 @@ test( "Modify cue or trackevent w/o update function provided", 3, function() {
 
 });
 
+test( "Modify plugin w/o provided update for plugins that use function that returns object", 2, function() {
+  var $pop = Popcorn( "#video" ),
+      count = 0,
+      id = "test-id",
+      updateOptions = {
+        text: "New Text"
+      };
+
+  Popcorn.plugin( "weirdstyle", function( options ) {
+
+    if ( ++count === 2 ) {
+      ok( true, "Function acting as setup was called again after update" );
+      deepEqual( options.text, updateOptions.text, "Update options were merged correctly" );
+    }
+
+    return {
+      start: function() {},
+      end: function() {},
+      _teardown: function() {}
+    };
+  });
+
+  $pop.weirdstyle( id, {} );
+
+  $pop.weirdstyle( id, updateOptions );
+
+  Popcorn.removePlugin( "weirdstyle" );
+  $pop.destroy();
+});
+
 module( "Popcorn XHR" );
 test( "Basic", 2, function() {
 


### PR DESCRIPTION
...instances _setup

https://webmademovies.lighthouseapp.com/projects/63272/tickets/1367-update-needs-to-re-run-plugin-definition-function-when-_update-is-not-defined#ticket-1367-8
