### PR TITLE
[#1320] Cache volume values for synch reasons, and properly update muted...

### DIFF
--- a/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
+++ b/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
@@ -502,7 +502,7 @@
     }
 
     function getVolume() {
-      // YouTube has getColume(), but for sync access we use impl.volume
+      // YouTube has getVolume(), but for sync access we use impl.volume
       return impl.volume;
     }
 


### PR DESCRIPTION
... cache value if added after media ready. Fix html5 to youtube volume scale. Youtube uses a scale of 0-100, html5 is 0-1.
