### PR TITLE
[#1375] Ensure that plugin definition methods (and in the future, track ...

### DIFF
--- a/test/popcorn.unit.js
+++ b/test/popcorn.unit.js
@@ -213,9 +213,16 @@ asyncTest( "TrackEvent instance integrity", 1, function() {
   });
 
   // Once https://github.com/mozilla/popcorn-js/pull/258 lands,
-  // uncomment to enable this
-  // p.on("tracksetup", function() {
-  //   references.push( options.data );
+  // the following should be uncommented:
+  //
+  // [
+  //   "tracksetup", "trackstart", "trackend", "trackteardown",
+  //   "trackadded", "trackremoved",
+  //   "trackchange"
+  // ].forEach(function( eventType ) {
+  //   p.on( eventType, function( event ) {
+  //     references.push( event.data );
+  //   });
   // });
 
   p.temp({


### PR DESCRIPTION
...event callbacks) receive a true reference to the TrackEvent object
