### PR TITLE
[#1462] Added in String.trim shim for IE8, fails without this.

### DIFF
--- a/ie8/popcorn.ie8.js
+++ b/ie8/popcorn.ie8.js
@@ -193,7 +193,7 @@
   if ( typeof String.prototype.trim !== "function" ) {
 
     String.prototype.trim = function() {
-      return this.replace(/^\s+|\s+$/g, '');
+      return this.replace(/^\s+|\s+$/g, "");
     };
   }
   


### PR DESCRIPTION
There is another failure in IE8, with "head.removeChild( script );" Looking to resolve this shortly.
