### PR TITLE
[#1463] IE8 fails at : "head.removeChild( script );"

### DIFF
--- a/ie8/popcorn.ie8.js
+++ b/ie8/popcorn.ie8.js
@@ -18,14 +18,23 @@
 
     event = ( event === "load" ) ? "onreadystatechange" : "on" + event;
 
-    this.attachEvent( event, callBack );
+    if( event === "onreadystatechange" ){
+      callBack.readyStateCheck = callBack.readyStateCheck || function( e ){
+
+        if( self.readyState === "loaded" ){
+          callBack( e );
+        }
+      };
+    }
+
+    this.attachEvent( event, ( callBack.readyStateCheck || callBack ) );
   };
 
   HTMLScriptElement.prototype.removeEventListener = HTMLScriptElement.prototype.removeEventListener || function( event, callBack ) {
 
     event = ( event === "load" ) ? "onreadystatechange" : "on" + event;
 
-    this.detachEvent( event, callBack );
+    this.detachEvent( event, ( callBack.readyStateCheck || callBack ) );
   };
 
   document.createEvent = document.createEvent || function ( type ) {


### PR DESCRIPTION
Patched HTMLScriptElement.prototype.addEventListener and HTMLScriptElement.prototype.removeEventListener to take into consideration how onreadystatechange actually works.
