### PR TITLE
Updating current time after checking to fire events

### DIFF
--- a/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
+++ b/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
@@ -390,11 +390,11 @@
     function monitorCurrentTime() {
       var playerTime = player.getCurrentTime();
       if ( !impl.seeking ) {
-        impl.currentTime = playerTime;
         if ( ABS( impl.currentTime - playerTime ) > CURRENT_TIME_MONITOR_MS ) {
           onSeeking();
           onSeeked();
         }
+        impl.currentTime = playerTime;
       } else if ( ABS( playerTime - impl.currentTime ) < 1 ) {
         onSeeked();
       }


### PR DESCRIPTION
In the latest version current time is always updated before comparing to current player time which prevent "seeking" event to be fired.
