### PR TITLE
Bug 898607 - Listen for durationchange events so internal data tracking ...

### DIFF
--- a/popcorn.js
+++ b/popcorn.js
@@ -250,6 +250,49 @@
           end: videoDurationPlus
         });
 
+        if ( !self.isDestroyed ) {
+          self.data.durationChange = function() {
+            var newDuration = self.media.duration,
+                byStart = self.data.trackEvents.byStart,
+                byEnd = self.data.trackEvents.byEnd;
+
+            // Remove old padding events
+            byStart.pop();
+            byEnd.pop();
+
+            // Remove any internal tracking of events that have end times greater than duration
+            // otherwise their end events will never be hit.
+            for ( var k = byEnd.length - 1; k > 0; k-- ) {
+              if ( byEnd[ k ].end > newDuration ) {
+                self.removeTrackEvent( byEnd[ k ]._id );
+              }
+            }
+
+            // Remove any internal tracking of events that have end times greater than duration
+            // otherwise their end events will never be hit.
+            for ( var i = 0; i < byStart.length; i++ ) {
+              if ( byStart[ i ].end > newDuration ) {
+                self.removeTrackEvent( byStart[ i ]._id );
+              }
+            }
+
+            // References to byEnd/byStart are reset, so accessing it this way is
+            // forced upon us.
+            self.data.trackEvents.byEnd.push({
+              start: newDuration,
+              end: newDuration
+            });
+
+            self.data.trackEvents.byStart.push({
+              start: newDuration,
+              end: newDuration
+            });
+          };
+
+          // Listen for duration changes and adjust internal tracking of event timings
+          self.media.addEventListener( "durationchange", self.data.durationChange, false );
+        }
+
         if ( self.options.frameAnimation ) {
 
           //  if Popcorn is created with frameAnimation option set to true,

--- a/test/core.html
+++ b/test/core.html
@@ -9,6 +9,8 @@
 
   <script src="popcorn.unit.setup.js"></script>
   <script src="../popcorn.js"></script>
+  <script src="../wrappers/common/popcorn._MediaElementProto.js"></script>
+  <script src="../wrappers/null/popcorn.HTMLNullVideoElement.js"></script>
   <script src="popcorn.unit.js"></script>
   <script src="inject.js"></script>
   <script src="popcorn.inject.js"></script>
@@ -55,6 +57,9 @@
     <p>Your user agent does not support the HTML5 Video element.</p>
 
   </video>
+
+  <!-- Used for durationchange tests -->
+  <div id="null-video"></div>
 
 
   <audio id="audio" data-timeline-sources="data/parserData.json" controls muted>

--- a/test/popcorn.unit.js
+++ b/test/popcorn.unit.js
@@ -1021,6 +1021,50 @@ test( "Bogus Selector", 2, function() {
   }
 });
 
+asyncTest( "durationchange", 7, function() {
+  var media = Popcorn.HTMLNullVideoElement( "#null-video" ),
+      pop;
+
+  Popcorn.plugin( "durationPlugin" , function(){
+    return {
+      _setup: function( options ) {},
+      start: function( event, options ) {},
+      end: function( event, options ) {},
+      _teardown: function( options ) {
+        ok( true, "Teardown was called when trackevents removed from durationchange" );
+      }
+    };
+  });
+
+  // Set initial duration to a 20 second video
+  media.src = "#t=,20";
+  pop = Popcorn( media );
+
+  pop.durationPlugin({ start: "12", end: "14" });
+
+  pop.on( "durationchange", function() {
+    pop.off( "durationchange" );
+
+    var byStart = pop.data.trackEvents.byStart,
+        byEnd = pop.data.trackEvents.byEnd;
+
+    equal( byStart.length, 2, "byStart should only contain the padding trackevents" );
+    equal( byEnd.length, 2, "byEnd should only contain the padding trackevents" );
+    ok( byStart[ 1 ].end === 10, "Padding event value should be equal to new duration. byStart.end" );
+    ok( byStart[ 1 ].start === 10, "Padding event value should be equal to new duration. byStart.start" );
+    ok( byEnd[ 1 ].end === 10, "Padding event value should be equal to new duration. byEnd.end" );
+    ok( byEnd[ 1 ].start === 10, "Padding event value should be equal to new duration. byEnd.start" );
+
+    Popcorn.removePlugin( "durationPlugin" );
+    pop.destroy();
+    start();
+  });
+
+  // Change to a media source with a different duration,
+  // and with a duration less than the start of our one trackevent
+  pop.media.src = "#t=,10";
+});
+
 module( "Popcorn Static" );
 
 test( "Popcorn.[addTrackEvent | removeTrackEvent].ref()", 2, function() {


### PR DESCRIPTION
...events can be adjusted

https://bugzilla.mozilla.org/show_bug.cgi?id=898607

Still need to figure out a good way to test this considering it relies on setting `p.media.src = newSrc`; to trigger this and we don't have different duration audio/video in the repo!
