### PR TITLE
[bug965048] - Fixed protocol to 'https' when embedding soundcloud audios

### DIFF
--- a/wrappers/soundcloud/popcorn.HTMLSoundCloudAudioElement.js
+++ b/wrappers/soundcloud/popcorn.HTMLSoundCloudAudioElement.js
@@ -13,8 +13,8 @@
   function isSoundCloudReady() {
     // If the SoundCloud Widget API + JS SDK aren't loaded, do it now.
     if( !scLoaded ) {
-      Popcorn.getScript( "//w.soundcloud.com/player/api.js", function() {
-        Popcorn.getScript( "//connect.soundcloud.com/sdk.js", function() {
+      Popcorn.getScript( "https://w.soundcloud.com/player/api.js", function() {
+        Popcorn.getScript( "https://connect.soundcloud.com/sdk.js", function() {
           scReady = true;
 
           // XXX: SoundCloud won't let us use real URLs with the API,


### PR DESCRIPTION
-> https://bugzilla.mozilla.org/show_bug.cgi?id=965048
