### PR TITLE
Prefix player_id in Vimeo wrapper to work around bug in current player

### DIFF
--- a/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js
+++ b/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js
@@ -74,7 +74,7 @@
         error: null
       },
       playerReady = false,
-      playerUID = Popcorn.guid(),
+      playerUID = Popcorn.guid("player_"),
       player,
       playerPaused = true,
       playerReadyCallbacks = [],


### PR DESCRIPTION
Fix for issue https://github.com/mozilla/popcorn-js/issues/417.

An update to the Vimeo player on November 20th, 2014 breaks Popcorn support by ignoring numeric values for player_id when firing events. This fix simply prefixes the ID with a string, causing Vimeo player events to return it properly.
