### PR TITLE
Allow multiple sources for JW player

### DIFF
--- a/wrappers/jwplayer/popcorn.HTMLJWPlayerVideoElement.js
+++ b/wrappers/jwplayer/popcorn.HTMLJWPlayerVideoElement.js
@@ -237,13 +237,14 @@
         destroyPlayer();
       }
 
-      //ExecOnline: allow source to be a hash
       var params = {
         width: "100%",
         height: "100%",
         controls: impl.controls
       };
 
+      // Source can either be a single file or multiple files that represent
+      // different quality
       if(typeof aSrc == "string"){
         params["file"] = aSrc;
       } else {


### PR DESCRIPTION
JWPlayer allows [multiple source](http://support.jwplayer.com/customer/portal/articles/1428524-hd-quality-toggling) files for different bitrate for users to choose from a menu

![Alt text](https://monosnap.com/image/8zeWQiT4Iw2Uw5DOGeMvhT5LxWwpQn.png)

This PR attempts to give them flexibility to popcorn while not breaking existing usage. If accepted, I will be happy to update the docs as well. 
