### PR TITLE
Test 34 typo makes it fail with an exception.

### DIFF
--- a/wrappers/common/common.unit.js
+++ b/wrappers/common/common.unit.js
@@ -704,7 +704,7 @@ asyncTest( "T34 - paused state during autoplay", 10, function() {
 
   var video = testData.createMedia( "#video" ),
       loadedMetaDataFired = false,
-      canplayFired = false,
+      canPlayFired = false,
       playFired = false,
       playingFired = false,
       canPlayThrough = false;


### PR DESCRIPTION
The variable "canPlayFired" is undefined because it's declared as "canplayFired". When everything is ok the "canPlayFired" variable will be created (globally!) when the "canplay" event fires and the problem is not noticed. But if "canplay" hasn't been fired before "play", an exception will be thrown when asserting the value of "canPlayFired".
