### PR TITLE
Add ability to set HTML element and CSS selector of footnotes.

### DIFF
--- a/plugins/footnote/popcorn.footnote.js
+++ b/plugins/footnote/popcorn.footnote.js
@@ -54,6 +54,11 @@
           type: "text",
           label: "Text"
         },
+        element: {
+          elem: "input",
+          type: "text",
+          label: "Element"
+        },
         target: "footnote-container"
       }
     },

--- a/plugins/footnote/popcorn.footnote.js
+++ b/plugins/footnote/popcorn.footnote.js
@@ -23,6 +23,8 @@
    *      start: 5, // seconds
    *      end: 15, // seconds
    *      text: 'This video made exclusively for drumbeat.org',
+   *      element: 'li',
+   *      selector: 'footnote',
    *      target: 'footnotediv'
    *    });
    **/

--- a/plugins/footnote/popcorn.footnote.js
+++ b/plugins/footnote/popcorn.footnote.js
@@ -59,6 +59,11 @@
           type: "text",
           label: "Element"
         },
+        selector: {
+          elem: "input",
+          type: "text",
+          label: "Selector"
+        },
         target: "footnote-container"
       }
     },

--- a/plugins/footnote/popcorn.footnote.js
+++ b/plugins/footnote/popcorn.footnote.js
@@ -11,6 +11,9 @@
    * Text is the text that you want to appear in the target
    * Target is the id of the document element that the text needs to be
    * attached to, this target element must exist on the DOM
+   * Options parameter can take element or selector.
+   * Element will override the default div element and append a valid HTML element to the DOM
+   * Selector will add the CSS class of your choice to the appended footnotes
    *
    * @param {Object} options
    *

--- a/plugins/footnote/popcorn.footnote.js
+++ b/plugins/footnote/popcorn.footnote.js
@@ -72,7 +72,14 @@
 
       var target = Popcorn.dom.find( options.target );
 
-      options._container = document.createElement( "div" );
+      if (options.element) {
+        options._container = document.createElement(options.element);
+      } else {
+        options._container = document.createElement("div");
+      }
+      if (options.selector) {
+        options._container.classList.add(options.selector);
+      }
       options._container.style.display = "none";
       options._container.innerHTML  = options.text;
 

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -55,7 +55,7 @@ test( "Popcorn Footnote Plugin", function() {
   });
 
   popped.exec( 3, function() {
-    equal( footnotediv.children[ 1 ].style.display, "inline", "second footnote is visible on the page" );
+    equal( footnotediv.children[ 2 ].style.display, "inline", "second footnote is visible on the page" );
     plus();
   });
 

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -1,7 +1,7 @@
 test( "Popcorn Footnote Plugin", function() {
 
   var popped = Popcorn( "#video" ),
-      expects = 11,
+      expects = 12,
       count = 0,
       setupId,
       footnotediv = document.getElementById( "footnotediv" );

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -52,6 +52,8 @@ test( "Popcorn Footnote Plugin", function() {
     plus();
     equal( footnotediv.children[ 0 ].style.display, "inline", "footnote is visible on the page" );
     plus();
+    equal( footnotediv.children [ 0 ].nodeName, "DIV", "Default HTML element is a div");
+    plus();
   });
 
   popped.exec( 1, function() {

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -1,7 +1,7 @@
 test( "Popcorn Footnote Plugin", function() {
 
   var popped = Popcorn( "#video" ),
-      expects = 10,
+      expects = 11,
       count = 0,
       setupId,
       footnotediv = document.getElementById( "footnotediv" );

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -16,7 +16,7 @@ test( "Popcorn Footnote Plugin", function() {
 
   stop();
 
-  ok( "footnote" in popped, "footnote is a mehtod of the popped instance" );
+  ok( "footnote" in popped, "footnote is a method of the popped instance" );
   plus();
 
   equal( footnotediv.childElementCount, 0, "initially, there is nothing inside the footnotediv" );

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -38,7 +38,7 @@ test( "Popcorn Footnote Plugin", function() {
   setupId = popped.getLastTrackEventId();
 
   popped.exec( 0, function() {
-    equal( footnotediv.childElementCount, 2, "footnotediv now has two inner elements" );
+    equal( footnotediv.childElementCount, 3, "footnotediv now has three inner elements" );
     plus();
     equal( footnotediv.children[ 0 ].innerHTML, "This video made exclusively for drumbeat.org", "footnote displaing correct information" );
     plus();

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -29,6 +29,14 @@ test( "Popcorn Footnote Plugin", function() {
     target: "footnotediv"
   })
   .footnote({
+    start: 1,
+    end: 2,
+    text: "Element and selector test",
+    element: "li",
+    selector: "selector-test",
+    target: "footnotediv"
+  })
+  .footnote({
     start: 2,
     end: 4,
     text: "Visit webmademovies.org for more details",

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -54,6 +54,11 @@ test( "Popcorn Footnote Plugin", function() {
     plus();
   });
 
+  popped.exec( 1, function() {
+    equal( footnotediv.children[ 1 ].className, "selector-test", "CSS selector is set by selector options parameter");
+    plus();
+  });
+
   popped.exec( 3, function() {
     equal( footnotediv.children[ 2 ].style.display, "inline", "second footnote is visible on the page" );
     plus();

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -57,6 +57,8 @@ test( "Popcorn Footnote Plugin", function() {
   popped.exec( 1, function() {
     equal( footnotediv.children[ 1 ].className, "selector-test", "CSS selector is set by selector options parameter");
     plus();
+    equal( footnotediv.children[ 1 ].nodeName, "LI", "HTML element is set by element options parameter");
+    plus();
   });
 
   popped.exec( 3, function() {

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -54,6 +54,8 @@ test( "Popcorn Footnote Plugin", function() {
     plus();
     equal( footnotediv.children [ 0 ].nodeName, "DIV", "Default HTML element is a div");
     plus();
+    equal ( footnotediv.children [ 0 ].className, "", "No CSS selector is set by default");
+    plus();
   });
 
   popped.exec( 1, function() {

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -1,7 +1,7 @@
 test( "Popcorn Footnote Plugin", function() {
 
   var popped = Popcorn( "#video" ),
-      expects = 8,
+      expects = 10,
       count = 0,
       setupId,
       footnotediv = document.getElementById( "footnotediv" );

--- a/plugins/footnote/popcorn.footnote.unit.js
+++ b/plugins/footnote/popcorn.footnote.unit.js
@@ -64,7 +64,7 @@ test( "Popcorn Footnote Plugin", function() {
     plus();
 
     popped.pause().removeTrackEvent( setupId );
-    ok( !footnotediv.children[ 1 ], "removed footnote was properly destroyed" );
+    ok( !footnotediv.children[ 2 ], "removed footnote was properly destroyed" );
     plus();
   });
   popped.play().volume( 0 );


### PR DESCRIPTION
Two options parameters to the footnote plugin were added, "element" which allows for the overriding of the default div element by the choice of the user and "selector" which allows for the optional addition of a CSS selector to appended footnotes. The footnote unit tests were updated and four additional tests were added to both test functionality of the two new parameters and ensure that default functionality of the footnote plugin was not altered.