### PR TITLE
Fixed VTT parser for IE8

### DIFF
--- a/parsers/parserVTT/popcorn.parserVTT.js
+++ b/parsers/parserVTT/popcorn.parserVTT.js
@@ -30,11 +30,11 @@
         lines,
         text,
         sub,
-        rNewLine = /(?:\r\n|\r|\n)/gm;
+        rNewLine = /\r\n|\n\r|\n|\r/g;
 
     // Here is where the magic happens
     // Split on line breaks
-    lines = data.text.split( rNewLine );
+    lines = data.text.replace( rNewLine, "\n" ).split( "\n" );
     len = lines.length;
 
     // Check for BOF token


### PR DESCRIPTION
Hello, I was working on subtitles implementation, and find out that VTT subtitles are not parsed correctly in IE8. So I've changed regular expression to support it. Works in other browsers as well.