### PR TITLE
Workaround for IE not seeking to exactly 0 during setup.

### DIFF
--- a/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
+++ b/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
@@ -219,7 +219,9 @@
 
     function onFirstPause() {
       removeYouTubeEvent( "pause", onFirstPause );
-      if ( player.getCurrentTime() > 0 ) {
+      // IE sometimes refuses to seek to exactly 0.
+      var playerTime = player.getCurrentTime();
+      if ( playerTime > 0 && !( playerTime < 0.2 && !impl.seeking && playerState === YT.PlayerState.PAUSED ) ) {
         setTimeout( onFirstPause, 0 );
         return;
       }
@@ -240,8 +242,8 @@
         return;
       }
       addYouTubeEvent( "pause", onFirstPause );
-      player.seekTo( 0 );
       player.pauseVideo();
+      player.seekTo( 0 );
     }
 
     function addYouTubeEvent( event, listener ) {


### PR DESCRIPTION
This is a workaround for the issue #453 where IE (11) will not seek to 0 after the first play/pause toggling while setting up the YouTube wrapper.

Without this patch the wrapper is stuck, paused and not seeking, waiting for the current time (as reported by the YT API) to become 0 before firing the ready event. This seems to be related to browser caching as it rarely, if at all, happens when files are first fetched by the browser but it's much more common once the page is reloaded with the caches full.

I also noticed that if calling Popcorn's ```currentTime()``` after the video has been setup (and not yet played) method it would not report 0 unless the ```player.seek( 0 )``` call was moved to after the ```player.pauseVideo()``` call.