### PR TITLE
Workaround for missing pause event in Youtube on Chrome

### DIFF
--- a/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
+++ b/wrappers/youtube/popcorn.HTMLYouTubeVideoElement.js
@@ -217,7 +217,9 @@
       self.dispatchEvent( "canplaythrough" );
     }
 
-    function onFirstPause() {
+    function onFirstPause(timeoutID) {
+      if (timeoutID)
+        clearTimeout(timeoutID);
       removeYouTubeEvent( "pause", onFirstPause );
       if ( player.getCurrentTime() > 0 ) {
         setTimeout( onFirstPause, 0 );
@@ -239,7 +241,9 @@
         setTimeout( onFirstPlay, 0 );
         return;
       }
-      addYouTubeEvent( "pause", onFirstPause );
+      // On Chrome the pause event is not fired
+      // so we back it with a timeout
+      addYouTubeEvent( "pause", onFirstPause, setTimeout(onFirstPause, 200) );
       player.seekTo( 0 );
       player.pauseVideo();
     }


### PR DESCRIPTION
This is a fix for issue #458 where the pause event is not fired in Youtube HTML on Chrome, meaning that player initialization does not complete.