### PR TITLE
Wikipedia fix

### DIFF
--- a/plugins/wikipedia/popcorn.wikipedia.js
+++ b/plugins/wikipedia/popcorn.wikipedia.js
@@ -107,19 +107,21 @@ var wikiCallback;
       // and stores it by appending values to the options object
       window[ "wikiCallback" + _guid ]  = function ( data ) {
 
+        var pageId = Object.keys(data.query.pages)[0];
+        var content = data.query.pages[pageId];
+
         options._link = document.createElement( "a" );
         options._link.setAttribute( "href", options.src );
         options._link.setAttribute( "target", "_blank" );
 
         // add the title of the article to the link
-        options._link.innerHTML = options.title || data.parse.displaytitle || data.parse.title;
+        options._link.innerHTML = options.title || content.title;
 
         // get the content of the wiki article
         options._desc = document.createElement( "p" );
 
-        // get the article text and remove any special characters
-        _text = data.parse.text[ "*" ].substr( data.parse.text[ "*" ].indexOf( "<p>" ) );
-        _text = _text.replace( /((<(.|\n)+?>)|(\((.*?)\) )|(\[(.*?)\]))/g, "" );
+        // get the article text
+        _text = content.extract;
 
         _text = _text.split( " " );
         options._desc.innerHTML = ( _text.slice( 0, ( _text.length >= options.numberofwords ? options.numberofwords : _text.length ) ).join (" ") + " ..." ) ;
@@ -128,7 +130,7 @@ var wikiCallback;
       };
 
       if ( options.src ) {
-        Popcorn.getScript( "//" + options.lang + ".wikipedia.org/w/api.php?action=parse&prop=text&redirects&page=" +
+        Popcorn.getScript( "//" + options.lang + ".wikipedia.org/w/api.php?action=query&prop=extracts&exintro=&explaintext=&redirects&titles=" +
           options.src.slice( options.src.lastIndexOf( "/" ) + 1 )  + "&format=json&callback=wikiCallback" + _guid );
       }
 

--- a/plugins/wikipedia/popcorn.wikipedia.js
+++ b/plugins/wikipedia/popcorn.wikipedia.js
@@ -112,7 +112,7 @@ var wikiCallback;
         options._link.setAttribute( "target", "_blank" );
 
         // add the title of the article to the link
-        options._link.innerHTML = options.title || data.parse.displaytitle;
+        options._link.innerHTML = options.title || data.parse.displaytitle || data.parse.title;
 
         // get the content of the wiki article
         options._desc = document.createElement( "p" );
@@ -128,7 +128,7 @@ var wikiCallback;
       };
 
       if ( options.src ) {
-        Popcorn.getScript( "//" + options.lang + ".wikipedia.org/w/api.php?action=parse&props=text&redirects&page=" +
+        Popcorn.getScript( "//" + options.lang + ".wikipedia.org/w/api.php?action=parse&prop=text&redirects&page=" +
           options.src.slice( options.src.lastIndexOf( "/" ) + 1 )  + "&format=json&callback=wikiCallback" + _guid );
       }
 

--- a/plugins/wikipedia/popcorn.wikipedia.unit.js
+++ b/plugins/wikipedia/popcorn.wikipedia.unit.js
@@ -42,7 +42,7 @@ test( "Popcorn wikipedia Plugin", function() {
       src: "http://en.wikipedia.org/wiki/Bunny",
       title: "This is an article about bunnies",
       target: "wikidiv",
-      numberofwords: 1000
+      numberofwords: 80
     })
     .volume( 0 )
     .play();
@@ -59,7 +59,7 @@ test( "Popcorn wikipedia Plugin", function() {
     // subtract 1 from length for the  '...' added in by the plugin
     equal( theArticle.children[ 1 ].innerHTML.split( " " ).length -1, 22, "wikidiv contains 22 words" );
     plus();
-    equal( theArticle.children[ 3 ].innerHTML.split( " " ).length - 1, 1000, "redirected article successfully retrieved 1000 words" );
+    equal( theArticle.children[ 3 ].innerHTML.split( " " ).length - 1, 80, "redirected article successfully retrieved 80 words" );
     plus();
   });
 


### PR DESCRIPTION
This is a fix for #464 so the correct parameters are used in the Wikipedia API call.

I also changed the API call so it only returns the main summary. Often long Wikipedia entries contain table of contents, etc. that look odd in a single block of text. The API 'extract' call lets us just get the main summary at the top of the Wikipedia entry.  This means it will be shorter, but probably more meaningful.