### PR TITLE
Allow fullscreen controls for embedded Vimeo Videos.

### DIFF
--- a/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js
+++ b/wrappers/vimeo/popcorn.HTMLVimeoVideoElement.js
@@ -427,9 +427,9 @@
       elem.style.width = "100%";
       elem.style.height = "100%";
       elem.frameBorder = 0;
-      elem.webkitAllowFullScreen = true;
-      elem.mozAllowFullScreen = true;
-      elem.allowFullScreen = true;
+      elem.setAttribute('webkitAllowFullScreen', '')
+      elem.setAttribute('mozAllowFullScreen', '')
+      elem.setAttribute('allowFullScreen', '')
       parent.appendChild( elem );
       elem.src = src;
 


### PR DESCRIPTION
`allowFullScreen` must be added to the iframe to enable fullscreen control on embedded Vimeo videos.  The old code was not successfully adding the fullscreen attributes to the iframe.  This change fixes the issue.
